### PR TITLE
[syslinux] Strip the .note.gnu.property section for the mbr. JB#61367

### DIFF
--- a/rpm/0016-strip-gnu-property.patch
+++ b/rpm/0016-strip-gnu-property.patch
@@ -1,0 +1,43 @@
+From: Lukas Schwaighofer <lukas@schwaighofer.name>
+Date: Sat, 18 Aug 2018 12:48:21 +0200
+Subject: Strip the .note.gnu.property section for the mbr
+
+This section is added since binutils Debian version 2.31.1-2 and causes mbr.bin
+to grow in size beyond what can fit into the master boot record.
+
+Forwarded: https://www.syslinux.org/archives/2018-August/026168.html
+---
+ mbr/i386/mbr.ld   | 6 +++++-
+ mbr/x86_64/mbr.ld | 6 +++++-
+ 2 files changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/mbr/i386/mbr.ld b/mbr/i386/mbr.ld
+index d14ba80..6d48990 100644
+--- a/mbr/i386/mbr.ld
++++ b/mbr/i386/mbr.ld
+@@ -69,5 +69,9 @@ SECTIONS
+   .debug_funcnames 0 : { *(.debug_funcnames) }
+   .debug_typenames 0 : { *(.debug_typenames) }
+   .debug_varnames  0 : { *(.debug_varnames) }
+-  /DISCARD/ : { *(.note.GNU-stack) }
++  /DISCARD/	  :
++  {
++    *(.note.GNU-stack)
++    *(.note.gnu.property)
++  }
+ }
+diff --git a/mbr/x86_64/mbr.ld b/mbr/x86_64/mbr.ld
+index ae27d49..5b46db6 100644
+--- a/mbr/x86_64/mbr.ld
++++ b/mbr/x86_64/mbr.ld
+@@ -68,5 +68,9 @@ SECTIONS
+   .debug_funcnames 0 : { *(.debug_funcnames) }
+   .debug_typenames 0 : { *(.debug_typenames) }
+   .debug_varnames  0 : { *(.debug_varnames) }
+-  /DISCARD/ : { *(.note.GNU-stack) }
++  /DISCARD/	  :
++  {
++    *(.note.GNU-stack)
++    *(.note.gnu.property)
++  }
+ }

--- a/rpm/syslinux.spec
+++ b/rpm/syslinux.spec
@@ -19,6 +19,7 @@ Patch0003: 0003-include-sysmacros-h.patch
 Patch0004: 0004-Add-RPMOPTFLAGS-to-CFLAGS-for-some-stuff.patch
 Patch0005: 0001-Fix-build-with-gcc8.patch
 Patch0006: 0001-Patch-out-git-dependency.patch
+Patch0007: 0016-strip-gnu-property.patch
 
 Autoreq: 0
 
@@ -60,14 +61,7 @@ All the SYSLINUX/PXELINUX modules directly available for network
 booting in the /tftpboot directory.
 
 %prep
-%setup -q -n %{name}-%{version}/%{name}
-
-%patch0001 -p1
-%patch0002 -p1
-%patch0003 -p1
-%patch0004 -p1
-%patch0005 -p1
-%patch0006 -p1
+%autosetup -p1 -n %{name}-%{version}/%{name}
 
 %build
 make clean


### PR DESCRIPTION
Patch from Debian to fix build issue with newer binutils.